### PR TITLE
[✨ Feature] 사용자 추가 여행지 기반 일정 재최적화 API 구현 (#38)

### DIFF
--- a/src/controllers/tripController.js
+++ b/src/controllers/tripController.js
@@ -22,8 +22,23 @@ exports.saveOptimizedRoute = async (req, res) => {
       console.error('최적 경로 저장 중 오류:', error);
       res.status(500).json({ message: '최적 경로 저장 실패' });
     }
+}
 exports.getTotalDistanceAndTime = async (req, res) => {
   const tripId = Number(req.params.tripId);
   const result = await tripService.calculateTotalDistanceAndTime(tripId);
   res.status(200).json(result);
+};
+exports.optimizeSchedule = async (req, res) => {
+  try {
+    const scheduleId = Number(req.params.scheduleId);
+    await tripService.optimizeScheduleById(scheduleId);
+    res.status(200).json({
+      scheduleId,
+      optimized: true,
+      message: '최적 경로 계산 완료'
+    });
+  } catch (error) {
+    console.error('스케줄 최적화 중 오류:', error);
+    res.status(500).json({ message: '최적 경로 계산 실패' });
+  }
 };

--- a/src/repositories/tripRepository.js
+++ b/src/repositories/tripRepository.js
@@ -1,4 +1,4 @@
-//const db = require('../config/database'); // 이건 너희 프로젝트에서 DB 연결 객체
+const db = require('../config/database'); // 이건 너희 프로젝트에서 DB 연결 객체
 
 // 여행일정 ID로 날짜별 장소 묶어서 가져오기
 exports.getPlacesGroupedByDate = async (tripId) => {
@@ -43,4 +43,38 @@ exports.updateVisitOrderAndDistance = async ({ tripId, placeId, date, order, dis
        WHERE 여행일정식별자 = ? AND 여행지식별자 = ? AND 방문날자 = ?`,
       [order, distance, tripId, placeId, date]
     );
+  };
+// 🧩 1. optimizeScheduleById - scheduleId로 mock 일정 구성
+exports.optimizeScheduleById = async (scheduleId) => {
+    const mock = {
+      "2025-06-01": [
+        { placeId: 1, name: "에펠탑", latitude: 48.8584, longitude: 2.2945 },
+        { placeId: 2, name: "루브르", latitude: 48.8606, longitude: 2.3376 }
+      ],
+      "2025-06-02": [
+        { placeId: 3, name: "개선문", latitude: 48.8738, longitude: 2.2950 }
+      ]
+    };
+  
+    const result = {};
+  
+    for (const [date, places] of Object.entries(mock)) {
+      result[date] = places.map((p, i) => ({
+        ...p,
+        order: i + 1,
+        distanceFromPrevious: i === 0 ? 0 : 3.0
+      }));
+    }
+  
+    await exports.updateVisitOrderAndDistanceBulk(scheduleId, result);
+    return result;
+  };
+  
+  // 🧩 2. updateVisitOrderAndDistanceBulk - console 로그 Mock 처리
+  exports.updateVisitOrderAndDistanceBulk = async (tripId, dataByDate) => {
+    for (const [date, places] of Object.entries(dataByDate)) {
+      for (const place of places) {
+        console.log(`[Mock] ${tripId} | ${place.name} | ${date} | 순서: ${place.order}, 거리: ${place.distanceFromPrevious}`);
+      }
+    }
   };

--- a/src/routes/tripRoute.js
+++ b/src/routes/tripRoute.js
@@ -81,11 +81,26 @@ const tripSharecontroller = require('../controllers/tripSharecontroller');
  *       200:
  *         description: 전체 이동 거리 및 시간 반환
  */
-
+/**
+ * @swagger
+ * /trip/schedule/{scheduleId}/optimize:
+ *   post:
+ *     summary: 일정 기반 최적 경로 재계산
+ *     parameters:
+ *       - in: path
+ *         name: scheduleId
+ *         required: true
+ *         schema:
+ *           type: integer
+ *         description: 일정 ID
+ *     responses:
+ *       200:
+ *         description: 최적 경로 계산 결과 반환
+ */
 // ✅ API 라우터들
 router.get('/:tripId/route', tripController.getOptimizedRoute);
 router.post('/:tripId/route/save', tripController.saveOptimizedRoute);
 router.put('/:shareId', tripSharecontroller.respondToShare);
 router.get('/:tripId/distance', tripController.getTotalDistanceAndTime);
-
+router.post('/schedule/:scheduleId/optimize', tripController.optimizeSchedule);
 module.exports = router;

--- a/src/services/routeOptimizerService.js
+++ b/src/services/routeOptimizerService.js
@@ -1,5 +1,6 @@
 const tripRepository = require('../repositories/tripRepository');
 const { calculateDistanceMatrix, solveTSP } = require('../utils/optimizerUtils');
+const routeOptimizer = require('./routeOptimizerService');
 
 exports.getOptimizedRouteByTripId = async (tripId) => {
   const placesByDate = await tripRepository.getPlacesGroupedByDate(tripId);
@@ -130,4 +131,11 @@ exports.getPlacesGroupedByDate = async (tripId) => {
       { placeId: 3, name: "개선문", latitude: 48.8738, longitude: 2.2950 }
     ]
   };
+};
+
+
+exports.optimizeScheduleById = async (scheduleId) => {
+  const placesByDate = await tripRepository.getPlacesGroupedByDate(scheduleId);
+  const optimized = await routeOptimizer.getOptimizedRouteByTripId(scheduleId);
+  await tripRepository.updateVisitOrderAndDistanceBulk(scheduleId, optimized);
 };


### PR DESCRIPTION
## ✅ 구현 내용
- `/trip/schedule/{scheduleId}/optimize` API 개발
- mock 기반 장소 목록 → TSP 기반 최적화 → 순서 및 거리 계산
- Swagger 문서 추가 및 정상 응답 확인
- 실제 DB 적용 전 mock console 로그로 테스트

## ✅ 테스트
- Swagger에서 테스트 요청 수행
- 응답 코드 200 확인
- 최적 경로 계산 완료 메시지 출력

Closes #38